### PR TITLE
Build site as part of test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-haskell@v1
@@ -34,3 +32,6 @@ jobs:
         cabal new-build
     - name: Run tests
       run: cabal new-test
+    - name: Run site build
+      run: |
+        cabal new-run mikey-bike -- build

--- a/journal/2021/01/16-journaling.md
+++ b/journal/2021/01/16-journaling.md
@@ -1,6 +1,6 @@
 ---
 title: A year of journaling
-date: 2021-01-16T07:30:00-0500
+dte: 2021-01-16T07:30:00-0500
 ---
 
 Every morning, I try to write down what happened the day before. I do this

--- a/journal/2021/01/16-journaling.md
+++ b/journal/2021/01/16-journaling.md
@@ -1,6 +1,6 @@
 ---
 title: A year of journaling
-dte: 2021-01-16T07:30:00-0500
+date: 2021-01-16T07:30:00-0500
 ---
 
 Every morning, I try to write down what happened the day before. I do this


### PR DESCRIPTION
This should cause CI to fail with content errors (misspelled metadata fields, etc).