### PR TITLE
link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ extraCss: root.css
   </div>
 
   <div class="item">
-    <h3><a href="/j">journal</a></h3>
+    <h3><a href="/j/index.html">journal</a></h3>
     <h4>(undefined)</h4>
   </div>
 </div>

--- a/templates/_footer_journal.html
+++ b/templates/_footer_journal.html
@@ -1,3 +1,3 @@
 <p>
-  <a href="/">mikey.bike</a> | <a href="/j">journal</a> | written by Michael Hoy
+  <a href="/">mikey.bike</a> | <a href="/j/index.html">journal</a> | written by Michael Hoy
 </p>

--- a/templates/_footer_notes.html
+++ b/templates/_footer_notes.html
@@ -1,3 +1,3 @@
 <p>
-  <a href="/">mikey.bike</a> | <a href="/notes">notes</a> | written by Michael Hoy
+  <a href="/">mikey.bike</a> | <a href="/notes/index.html">notes</a> | written by Michael Hoy
 </p>


### PR DESCRIPTION
Cloudfront doesn't support `directory/` links mapping to `directory/index.html` objects.