### PR TITLE
AssetHashing: use strict Data.ByteString

### DIFF
--- a/src/AssetHashing.hs
+++ b/src/AssetHashing.hs
@@ -68,9 +68,7 @@ rewriteAssetUrls hashes item = do
 
 rewriteAssetUrls' :: FileHashes -> String -> String
 rewriteAssetUrls' hashes = withUrls rewrite
-  where rewrite url = maybe url
-                            (addHashToUrl url)
-                            (lookupHashForUrl hashes url)
+  where rewrite url = maybe url (addHashToUrl url) (lookupHashForUrl hashes url)
 
 lookupHashForUrl :: FileHashes -> String -> Maybe String
 lookupHashForUrl hashes url = Map.lookup (fromFilePath urlWithoutRootSlash) hashes

--- a/src/AssetHashing.hs
+++ b/src/AssetHashing.hs
@@ -13,9 +13,9 @@ module AssetHashing
 
 import           Control.Monad.Extra            ( forM )
 import qualified Crypto.Hash.SHA256            as SHA256
+import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Base16        as Base16
 import qualified Data.ByteString.Char8         as BS8
-import qualified Data.ByteString.Lazy          as BSL
 import qualified Data.Map                      as Map
 import           Data.Map                       ( Map )
 import           Data.Maybe                     ( fromMaybe )
@@ -42,7 +42,7 @@ type FileHashes = Map Identifier String
 
 hash :: FilePath -> IO String
 hash path = do
-  !h <- SHA256.hashlazy <$> BSL.readFile path
+  !h <- SHA256.hash <$> BS.readFile path
   pure $! BS8.unpack $! Base16.encode h
 
 mkFileHashes :: FilePath -> IO FileHashes
@@ -68,7 +68,9 @@ rewriteAssetUrls hashes item = do
 
 rewriteAssetUrls' :: FileHashes -> String -> String
 rewriteAssetUrls' hashes = withUrls rewrite
-  where rewrite url = maybe url (addHashToUrl url) (lookupHashForUrl hashes url)
+  where rewrite url = maybe url
+                            (addHashToUrl url)
+                            (lookupHashForUrl hashes url)
 
 lookupHashForUrl :: FileHashes -> String -> Maybe String
 lookupHashForUrl hashes url = Map.lookup (fromFilePath urlWithoutRootSlash) hashes


### PR DESCRIPTION
I don't really know why the implementation I was copying from used Data.ByteString.Lazy.